### PR TITLE
Fixed electron files browser for Multipart Form files

### DIFF
--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -42,9 +42,9 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
   // browse directory for file
   ipcMain.handle('renderer:browse-files', async (event, pathname, request, filters) => {
     try {
-      const filePath = await browseFiles(mainWindow, filters);
+      const filePaths = await browseFiles(mainWindow, filters);
 
-      return filePath;
+      return filePaths;
     } catch (error) {
       return Promise.reject(error);
     }

--- a/packages/bruno-electron/src/utils/filesystem.js
+++ b/packages/bruno-electron/src/utils/filesystem.js
@@ -105,7 +105,7 @@ const browseDirectory = async (win) => {
 
 const browseFiles = async (win, filters) => {
   const { filePaths } = await dialog.showOpenDialog(win, {
-    properties: ['multiSelections'],
+    properties: ['openFile', 'multiSelections'],
     filters
   });
 


### PR DESCRIPTION
Fixed the files browser that wasn't working on Mac. Now it has the same properties as the [example on the docs](https://www.electronjs.org/docs/latest/api/dialog).